### PR TITLE
OSE-730 remove hard coding of Elastic Beanstalk solution stack name

### DIFF
--- a/terraform-modules/lambda-takeover/code/takeover/eb-vpc.yaml
+++ b/terraform-modules/lambda-takeover/code/takeover/eb-vpc.yaml
@@ -16,6 +16,10 @@ Parameters:
     Type: String
     Default: domain-protect
 
+  SolutionStackName:
+    Description: AWS solution stack name
+    Type: String
+
   VpcCIDR:
     Description: IP range (CIDR notation) for VPC
     Type: String
@@ -163,7 +167,7 @@ Resources:
       - Namespace: aws:ec2:vpc
         OptionName: ELBSubnets
         Value: !Ref PublicSubnet1
-      SolutionStackName: 64bit Amazon Linux 2 v3.3.13 running PHP 8.0
+      SolutionStackName: !Ref SolutionStackName
 
   takeoverEnvironment:
     Type: AWS::ElasticBeanstalk::Environment

--- a/terraform-modules/lambda-takeover/code/takeover/takeover.py
+++ b/terraform-modules/lambda-takeover/code/takeover/takeover.py
@@ -11,6 +11,16 @@ sns_topic_arn = os.environ["SNS_TOPIC_ARN"]
 suffix = os.environ["SUFFIX"]
 
 
+def get_elastic_beanstalk_stack():
+    session = boto3.Session()
+    elasticbeanstalk = session.client("elasticbeanstalk")
+
+    solution_stacks = elasticbeanstalk.list_available_solution_stacks()["SolutionStacks"]
+    solution_stack = [s for s in solution_stacks if "Amazon Linux 2 " in s and "PHP" in s][0]
+
+    return solution_stack
+
+
 def create_stack(region, template, takeover_domain, vulnerable_domain, account):
 
     session = boto3.Session(region_name=region)
@@ -28,6 +38,7 @@ def create_stack(region, template, takeover_domain, vulnerable_domain, account):
             {"ParameterKey": "DomainName", "ParameterValue": takeover_domain.rsplit(".", 3)[0]},
             {"ParameterKey": "BucketName", "ParameterValue": f"{project}-{sanitised_domain}-content-{suffix}"[:63]},
             {"ParameterKey": "EnvironmentName", "ParameterValue": project},
+            {"ParameterKey": "SolutionStackName", "ParameterValue": get_elastic_beanstalk_stack()},
         ]
         resource_name = stack_name
 


### PR DESCRIPTION
The Elastic Beanstalk CloudFormation template specifies an Elastic Beanstalk solution stack 64bit Amazon Linux 2 v3.3.13 running PHP 8.0. When this is upgraded, e.g. to Amazon Linux 2 v3.3.14, AWS removes the old version and takeover fails.

Fixed by getting the latest version and passing in to the template as a parameter