### PR TITLE
OSE-751 new vulnerable NS test used by update lambda

### DIFF
--- a/terraform-modules/lambda/code/update/update.py
+++ b/terraform-modules/lambda/code/update/update.py
@@ -5,7 +5,7 @@ import os
 from utils.utils_aws import publish_to_sns
 from utils.utils_aws_ips import vulnerable_aws_a_record
 from utils.utils_db import db_list_all_unfixed_vulnerabilities, db_vulnerability_fixed
-from utils.utils_dns import dns_deleted, vulnerable_ns, vulnerable_alias, vulnerable_cname
+from utils.utils_dns import dns_deleted, vulnerable_ns_update, vulnerable_alias, vulnerable_cname
 from utils.utils_requests import vulnerable_storage, get_all_aws_ips
 
 ip_time_limit = os.environ["IP_TIME_LIMIT"]
@@ -26,7 +26,7 @@ def lambda_handler(event, context):  # pylint:disable=unused-argument
         account = vulnerability["Account"]["S"]
 
         if vulnerability_type == "NS":
-            if not vulnerable_ns(domain):
+            if not vulnerable_ns_update(domain):
                 db_vulnerability_fixed(domain)
                 json_data["Fixed"].append(
                     {"Account": account, "Cloud": cloud, "Domain": domain, "ResourceType": resource_type}

--- a/utils/utils_dns.py
+++ b/utils/utils_dns.py
@@ -69,3 +69,29 @@ def dns_deleted(domain_name):
         return False
 
     return False
+
+
+def vulnerable_ns_update(domain_name):
+    # used by update Lambda to check if a Vulnerable NS record has been fixed
+    # same as vulnerable_ns except returns True if no answer or timeout
+
+    try:
+        dns.resolver.resolve(domain_name)
+
+    except dns.resolver.NXDOMAIN:
+        return False
+
+    except dns.resolver.NoNameservers:
+
+        try:
+            ns_records = dns.resolver.resolve(domain_name, "NS")
+            if len(ns_records) == 0:
+                return True
+
+        except dns.resolver.NoNameservers:
+            return True
+
+    except (dns.resolver.NoAnswer, dns.resolver.Timeout):
+        return True
+
+    return False


### PR DESCRIPTION
The update Lambda occasionally reports a NS vulnerability as fixed when this is not the case.

This is believed to be due to occasional timeouts of the DNS request. The logic has been updated so that if there is a timeout, the NS vulnerability is assumed to still be present.