### PR TITLE
OSE-1137 vulnerable_ns function improvements

### DIFF
--- a/integration_tests/manual_scans/cloudflare/test_manual_cf_ns.py
+++ b/integration_tests/manual_scans/cloudflare/test_manual_cf_ns.py
@@ -6,7 +6,7 @@ from manual_scans.cloudflare.cf_ns import main
 
 @patch("manual_scans.cloudflare.cf_ns.print_list")
 def test_cf_ns_prints_ns_with_no_name_server(print_list_mock, cloudflare_mock, dns_mock):
-    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NoNameservers)
+    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NoNameservers, record_type="NS")
 
     cloudflare_mock.add_zone("test1.co.uk").add_dns("sub.ns.co.uk", "NS", "sub.ns.co.uk").build()
 
@@ -37,7 +37,7 @@ def test_cf_ns_ignores_ns_records_where_name_matches_zone(print_list_mock, cloud
 
 @patch("manual_scans.cloudflare.cf_ns.my_print")
 def test_cf_prints_insecure_domains(my_print_mock, cloudflare_mock, dns_mock):
-    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NoNameservers)
+    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NoNameservers, record_type="NS")
 
     cloudflare_mock.add_zone("test1.co.uk").add_dns("sub.ns.co.uk", "NS", "sub.ns.co.uk").build()
 
@@ -49,7 +49,7 @@ def test_cf_prints_insecure_domains(my_print_mock, cloudflare_mock, dns_mock):
 
 @patch("manual_scans.cloudflare.cf_ns.my_print")
 def test_cf_prints_secure_domains(my_print_mock, cloudflare_mock, dns_mock):
-    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NXDOMAIN)
+    dns_mock.add_lookup("sub.ns.co.uk", "sub.ns.co.uk", exception=dns.resolver.NXDOMAIN, record_type="NS")
 
     cloudflare_mock.add_zone("test1.co.uk").add_dns("sub.ns.co.uk", "NS", "sub.ns.co.uk").build()
 

--- a/unittests/utils/test_utils_dns.py
+++ b/unittests/utils/test_utils_dns.py
@@ -32,8 +32,8 @@ def test_vulnerable_ns_returns_true_when_no_A_nameserver_and_0_NS_records(resolv
 
 
 @patch("dns.resolver.resolve")
-def test_vulnerable_ns_returns_false_when_no_A_nameserver_and_1_NS_records(resolve_mock):
-    resolve_mock.side_effect = [NoNameservers, ["some result"]]
+def test_vulnerable_ns_returns_false_when_no_answer(resolve_mock):
+    resolve_mock.side_effect = NoAnswer
 
     result = vulnerable_ns("google.com")
 
@@ -41,12 +41,12 @@ def test_vulnerable_ns_returns_false_when_no_A_nameserver_and_1_NS_records(resol
 
 
 @patch("dns.resolver.resolve")
-def test_vulnerable_ns_returns_false_when_no_answer(resolve_mock):
+def test_vulnerable_ns_returns_true_when_no_answer_if_update_scan(resolve_mock):
     resolve_mock.side_effect = NoAnswer
 
-    result = vulnerable_ns("google.com")
+    result = vulnerable_ns("google.com", True)
 
-    assert_that(result).is_false()
+    assert_that(result).is_true()
 
 
 @patch("dns.resolver.resolve")
@@ -59,7 +59,7 @@ def test_vulnerable_ns_returns_false_on_timeout(resolve_mock):
 
 
 @patch("dns.resolver.resolve")
-def test_vulnerable_ns_returns_true_on_timeout_if_update_scan_is_true(resolve_mock):
+def test_vulnerable_ns_returns_true_on_timeout_if_update_scan(resolve_mock):
     resolve_mock.side_effect = Timeout
 
     result = vulnerable_ns("google.com", True)
@@ -90,7 +90,7 @@ def test_vulnerable_ns_prints_message_on_exception(resolve_mock, print_mock):
 
 @patch("builtins.print")
 @patch("dns.resolver.resolve")
-def test_vulnerable_ns_prints_message_on_exception_when_update_scan_is_true(resolve_mock, print_mock):
+def test_vulnerable_ns_prints_message_on_exception_if_update_scan(resolve_mock, print_mock):
     e = Exception("Exception message")
     resolve_mock.side_effect = e
     expected_message = f"Unhandled exception testing DNS for NS records during update scan: {e.args[0]}"

--- a/utils/utils_dns.py
+++ b/utils/utils_dns.py
@@ -9,22 +9,17 @@ resolver.resolve.nameservers = nameservers
 def vulnerable_ns(domain_name, update_scan=False):
 
     try:
-        resolver.resolve(domain_name)
+        resolver.resolve(domain_name, "NS")
 
     except resolver.NXDOMAIN:
         return False
 
     except resolver.NoNameservers:
-
-        try:
-            ns_records = resolver.resolve(domain_name, "NS")
-            if len(ns_records) == 0:
-                return True
-
-        except resolver.NoNameservers:
-            return True
+        return True
 
     except resolver.NoAnswer:
+        if update_scan:
+            return True
         return False
 
     except (resolver.Timeout):


### PR DESCRIPTION
- specify NS record type to avoid any possible issues where there is also an A record for the same domain name
- return True for update scans in the event of a NoAnswer response, to prevent incorrectly reporting issue as fixed
- remove check on number of name servers as this isn't required